### PR TITLE
Actualización de instrucciones de instalación de conda

### DIFF
--- a/Intro-a-Jupyter/instalacion-jlab-conda.md
+++ b/Intro-a-Jupyter/instalacion-jlab-conda.md
@@ -14,33 +14,35 @@
 <strong><a href="../enlaces.md">Enlaces</a></strong>
 </p>
 
-<img     style="float: left;" src="OHWe.png" width="100"> 
+<img style="float: left;" src="OHWe.png" width="100"> 
 
 # Instalación de Conda, Python y JupyterLab
 
 Instalaremos en tu computadora la aplicación `JupyterLab` con Python y algunos paquetes útiles, utilizando el sistema `conda`. 
 
-[Conda](https://docs.conda.io) es un administrador de paquetes y entornos para cualquier lenguaje de programación, pero especialmente popular en la comunidad de usuarios de Python. Permite la instalación de diferentes combinaciones y versiones de paquetes de software o librerías y de sus dependencias en diferentes entornos, con la capacidad de cambiar fácilmente de un entorno a otro, donde cada entorno contiene una configuración aislada de Python y paquetes que uno escoge, con versiones específicas; un entorno puede estar relacionado a un proyecto específico. Conda da acceso a miles de paquetes, y puede ser instalado en tu computadora sin necesidad de tener privilegios administrativos.
+[Conda](https://docs.conda.io) es un administrador de paquetes y entornos para cualquier lenguaje de programación, pero especialmente popular en la comunidad de usuarios de Python. Permite la instalación de diferentes combinaciones y versiones de paquetes de software o librerías y de sus dependencias en diferentes [entornos](https://exponentis.es/creacion-de-entornos-en-anaconda), con la capacidad de cambiar fácilmente de un entorno a otro. Cada entorno contiene una configuración aislada de Python y paquetes que uno escoge, con versiones específicas; un entorno puede estar relacionado a un proyecto específico. `Conda` da acceso a miles de paquetes, y puede ser instalado en tu computadora sin necesidad de tener privilegios administrativos.
 
-Conda funciona tanto en Windows como en macOS y Linux. Conda y los paquetes disponibles a través de conda son generalmente gratuitos y accesibles bajo licencias de código abierto. Hay diferentes maneras de instalar conda. Aquí utilizaremos [Miniconda](https://conda.io/miniconda.html), una distribución ligera de conda. Otra manera popular de instalar conda es a través de la distribución [Anaconda](https://www.anaconda.com/products/distribution), que pre-instala una gran cantidad de paquetes comunes de Python. Recomendamos Miniconda porque se instala más rápidamente, requiere menos espacio en el disco, y promueve la inclusión selectiva de los paquetes necesarios para proyectos específicos en entornos bien definidos.
+`Conda` funciona tanto en Windows como en macOS y Linux. `Conda` y los paquetes disponibles a través de `conda` son generalmente gratuitos y accesibles bajo licencias de código abierto. Hay diferentes maneras de instalar `conda`. Aquí utilizaremos [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main), una distribución ligera de `conda`. Otra manera popular de instalar `conda` es a través de la distribución [Anaconda](https://www.anaconda.com/docs/getting-started/anaconda/main), que pre-instala una gran cantidad de paquetes comunes de Python. **Recomendamos `Miniconda`** porque se instala más rápidamente, requiere menos espacio en el disco, y promueve la inclusión selectiva de paquetes necesarios para proyectos específicos en entornos bien definidos.
 
-En estos tutoriales iniciales no profundizaremos sobre conda más allá de lo necesario. Entraremos en más detalles durante el hackatón. Si quieres aprender más, visita los enlaces al final de esta página.
+> **Nota sobre la licencia:** Recientemente [Anaconda Inc.](https://www.datacamp.com/es/blog/anaconda-alternatives#c%C3%B3digo-abierto-y-licencias-aunqu), la compañía que distribuye `Anaconda` y `Miniconda`, ha [modificado su licencia con términos más restrictivos para uso comercial o en organizaciones grandes](https://www.datacamp.com/es/blog/anaconda-alternatives#c%C3%B3digo-abierto-y-licencias-aunqu). Esto no es ningún problema para uso individual o de grupos pequeños, pero para el futuro recomendamos el uso de la distribución [Miniforge](https://conda-forge.org/download/) que es 100% Código Abierto.
+
+En estos tutoriales iniciales no profundizaremos sobre `conda` más allá de lo necesario. Entraremos en más detalles durante el hackatón. Si quieres aprender más, visita los enlaces al final de esta página.
 
 ## Instalar Miniconda
 
-Incluimos instrucciones breves para instalar Miniconda. Puedes consultar los enlaces en "Referencias y recursos" para obtener ayuda adicional, incluyendo algunos videos en YouTube.
+Incluimos instrucciones breves para instalar `Miniconda`. Puedes consultar los enlaces en "Referencias y recursos" para obtener ayuda adicional, incluyendo algunos videos en YouTube.
 
 ### Windows
 
-En la página https://docs.conda.io/en/latest/miniconda.html, bajo "Latest Miniconda Installer Links", baja el instalador `Miniconda3 Windows 64bit`. Si tu computadora es vieja, tal vez la versión 32bit es la indicada. En Windows 10:
+En [esta página](https://www.anaconda.com/download/success#miniconda), bajo "Miniconda Installers" y "Windows", descarga el archivo en el enlace `64-Bit Graphical Installer` (alrededor de 90 MB). Ahora:
 
-- Haz doble clic en el archivo instalador después de bajarlo.
-- Selecciona la opción para instalar como usuario local solamente (local user only).
-- Acepta la ruta (*path*) de archivos de instalación de defecto, que probablemente será: `C:\Users\MIPERFIL\miniconda3`
-- En la ventana "Advanced Installation Options", desactiva la selección de ambas cajas ("Add Miniconda3 ..." y "Register Miniconda3 ...")
-- En la ventana "Completing Miniconda3", desactiva la selección de ambas cajas.
+- Ejecuta el archivo instalador (`.exe`) después de bajarlo. 
+- Continua hasta la ventana que da a escoger el tipo de instalación. Selecciona la opción para instalar como usuario local solamente (*Just me (recommended)*).
+- Acepta la ruta (*Destination Folder*) de archivos de instalación de defecto, probablemente: `C:\Users\MIPERFIL\AppData\Local\miniconda3`
+- En la ventana *Advanced Installation Options*, desactiva la selección de ambas cajas (*Add Miniconda3 ...* y *Register Miniconda3 ...*)
+- En la ventana *Completing Miniconda3*, desactiva la selección de ambas cajas.
 
-Cuando la instalación ha concluído, abre el "Anaconda Powershell Prompt" o "Anaconda Prompt" desde el menú de `Start`. Puedes comprobar que funciona bien corriendo el comando `conda list`.
+Cuando la instalación ha concluido, abre el *Anaconda PowerShell Prompt* o *Anaconda Prompt* desde el menú de `Start`. Puedes comprobar que funciona bien corriendo el comando `conda env list`.
 
 ### macOS o Linux
 
@@ -58,21 +60,29 @@ bash miniconda.sh -b -p $HOME/miniconda3
 
 Si el instalador te pregunta si quieres que inicialize Miniconda3 corriendo `conda init` ("Do you wish the installer to initialize Miniconda3 by running conda init?"), selecciona "yes". Si concluye sin hacer esa pregunta, ejecuta el siguiente comando: `./miniconda3/bin/conda init`. Por último, ejecuta el comando `conda update conda --yes`
 
-## Crear entorno conda para JupyterLab
+## Crear entorno de conda para JupyterLab
 
-Con conda ya instalado, el último paso es crear un entorno de conda que usaremos para correr la aplicación JupyterLab. Además de JupyterLab, este entorno incluirá Python 3.11 y tres paquetes de Python de uso amplio que también son utilizados en el tutorial de Python: `matplotlib`, `pandas` y `netcdf4`.
+Con conda ya instalado, el último paso es crear un entorno de conda que usaremos para correr la aplicación `JupyterLab`. Además de `JupyterLab`, este entorno incluirá **Python 3.12** y tres paquetes de Python de uso amplio que también son utilizados en el tutorial de Python: `matplotlib`, `pandas` y `netcdf4`.
 
-En la terminal donde instalaste miniconda, corre este comando de `conda create` para crear el entorno con el nombre "jupyterlab": `conda create --yes -n jupyterlab -c conda-forge python=3.11 jupyter jupyterlab-language-pack-es-ES nb_conda_kernels matplotlib-base pandas netcdf4`
+En la terminal donde instalaste miniconda, corre este comando de `conda create` para crear el entorno con el nombre `jupyterlab`: 
+```bash
+conda create --yes -n jupyterlab -c conda-forge python=3.12 jupyter jupyterlab-language-pack-es-ES nb_conda_kernels matplotlib pandas netcdf4
+```
 
-Este entorno contiene un "paquete de idioma" (*language pack*) de español que permite cambiar el interfaz de JupyterLab al español.
+[**conda-forge**](https://conda-forge.org) es un repositorio y "canal" de paquetes de `conda` administrado por una amplia comunidad internacional, que actualmente contiene casi 30 mil paquetes de código abierto. Recomendamos usar siempre este canal. El entorno contiene un "paquete de idioma" (*language pack*) de español que permite cambiar el interfaz de JupyterLab al español.
 
-(["conda-forge"](https://conda-forge.org) es un "canal" de paquetes de conda administrado por una gran comunidad internacional, que actualmente contiene más de 20 mil paquetes de código abierto). Recomendamos usar siempre este canal.
-
-En la terminal el nuevo entorno `jupyterlab` se activa con el comando `conda activate jupyterlab`, y se desactiva con el comando `conda deactivate`.
+En la terminal, el nuevo entorno `jupyterlab` se activa con el comando `conda activate jupyterlab`, y se desactiva con el comando `conda deactivate`.
 
 ## Entorno básico de Python
 
-Un entorno minimalista con Python (3.11) y nada más puede ser creado con este comando: `conda create --yes -n python -c conda-forge python=3.11`. Si omites la versión de Python, la versión más reciente será instalada. Si omites el argumento `--yes`, tendrás que dar tu aprobación para completar la instalación.
+Un entorno minimalista con Python (3.12) y nada más puede ser creado con este comando: `conda create --yes -n python -c conda-forge python=3.12`. Si omites la versión de Python, la versión más reciente será instalada. Si omites el argumento `--yes`, tendrás que dar tu aprobación para completar la instalación.
+
+## Añadir más paquetes a un entorno
+
+Podemos añadir paquetes adicionales a un entorno utilizando `conda install` luego de activar el entorno, manteniendo la referencia a `conda-forge`. Por ejemplo:
+```bash
+conda install -c conda-forge seaborn
+```
 
 ## Referencias y recursos
 

--- a/Intro-a-Jupyter/instalacion-jlab-conda.md
+++ b/Intro-a-Jupyter/instalacion-jlab-conda.md
@@ -60,7 +60,9 @@ bash miniconda.sh -b -p $HOME/miniconda3
 
 Si el instalador te pregunta si quieres que inicialize Miniconda3 corriendo `conda init` ("Do you wish the installer to initialize Miniconda3 by running conda init?"), selecciona "yes". Si concluye sin hacer esa pregunta, ejecuta el siguiente comando: `./miniconda3/bin/conda init`. Por último, ejecuta el comando `conda update conda --yes`
 
-## Crear entorno de conda para JupyterLab
+## Entornos con conda
+
+### Crear entorno de conda para JupyterLab
 
 Con conda ya instalado, el último paso es crear un entorno de conda que usaremos para correr la aplicación `JupyterLab`. Además de `JupyterLab`, este entorno incluirá **Python 3.12** y tres paquetes de Python de uso amplio que también son utilizados en el tutorial de Python: `matplotlib`, `pandas` y `netcdf4`.
 
@@ -73,16 +75,22 @@ conda create --yes -n jupyterlab -c conda-forge python=3.12 jupyter jupyterlab-l
 
 En la terminal, el nuevo entorno `jupyterlab` se activa con el comando `conda activate jupyterlab`, y se desactiva con el comando `conda deactivate`.
 
-## Entorno básico de Python
+### Entorno básico de Python
 
 Un entorno minimalista con Python (3.12) y nada más puede ser creado con este comando: `conda create --yes -n python -c conda-forge python=3.12`. Si omites la versión de Python, la versión más reciente será instalada. Si omites el argumento `--yes`, tendrás que dar tu aprobación para completar la instalación.
 
-## Añadir más paquetes a un entorno
+### Añadir más paquetes a un entorno
 
 Podemos añadir paquetes adicionales a un entorno utilizando `conda install` luego de activar el entorno, manteniendo la referencia a `conda-forge`. Por ejemplo:
 ```bash
 conda install -c conda-forge seaborn
 ```
+
+## Alternativas a conda
+
+`conda` es muy popular en ámbitos científicos y de ciencia de datos, ya que aborda muy bien el tipo de necesidades y desafíos comunes en estas áreas. En el uso de Python más general, el ecosistema de herramientas para la instalación de paquetes y gestión de entornos es más complejo.
+
+Para la instalación y gestión de paquetes, la herramienta más universal es [**pip**](https://es.wikipedia.org/wiki/Pip_(administrador_de_paquetes)) (ver también [este excelente artículo](https://www.programaenpython.com/avanzado/gestion-de-dependencias-en-python-con-pip/)). Actualmente, la herramienta [**uv**](https://www.mostapha.dev/blog/uv-gestor-paquetes-python-2025) está cobrando auge, ya que es mucho más rápida y cubre más capacidades, incluyendo la gestión de entornos.
 
 ## Referencias y recursos
 


### PR DESCRIPTION
- Actualizé enlaces e instrucciones
- Añadí mención de las nuevas limitaciones de la licencia de Anaconda, y de Miniforge como una buena alternativa
- Añadí sección sobre herramientas `pip` y `uv`
